### PR TITLE
Add TSViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - [(MDY) Randomix - Decision Maker](https://www.f-droid.org/packages/com.minar.randomix/) (FOSS)
 - [(MDY) Easter Egg (Android 12)](https://play.google.com/store/apps/details?id=rk.android.app.android12.easter.egg)
 - [(MDY) Workout Timer](https://play.google.com/store/apps/details?id=com.paget96.workouttimer)
+- [(MDY) TSViewer](https://github.com/BlazeCodeDev/TSViewer) (FOSS)
 ---
 ### 🎴 Icons / Wallpaper / Widgets
 - **Icons**


### PR DESCRIPTION
Hi,

This MR adds [TSViewer](https://github.com/BlazeCodeDev/TSViewer). I'm not sure if it's MDY or MY only?

For FOSS apps, I think it's better to provide the link to GitHub or Gitlab (and not directly the link to F-Droid), it gives the choice to the final user to get it either from F-Droid (if available), Google Play or the Releases Section of GitHub/GitLab.

Cheers