### PR TITLE
Changed Owl to FreeDictionaryApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MDY` [Android Studio Tutorials: Kotlin](https://github.com/D4rK7355608/com.d4rk.androidtutorials) <sup>`FOSS`</sup>
 - `MDY` [Android Studio Tutorials: Java](https://github.com/D4rK7355608/com.d4rk.androidtutorials.java) <sup>`FOSS`</sup>
 - `MDY` [English with Lidia Plus](https://github.com/D4rK7355608/com.d4rk.englishwithlidia.plus) <sup>`FOSS`</sup>
-- `MDY` [Owl](https://github.com/yamin8000/Owl2) <sup>`FOSS`</sup>
+- `MDY` [freeDictionaryApp](https://github.com/yamin8000/freeDictionaryApp) <sup>`FOSS`</sup>
 - `MDY` [Graded](https://github.com/NightDreamGames/Graded) <sup>`FOSS`</sup>
 - `MDY` [School Planner](https://play.google.com/store/apps/details?id=daldev.android.gradehelper)
 - `MDY` [Aristo Kids](https://play.google.com/store/apps/details?id=com.aristo.aristokids)


### PR DESCRIPTION
As OwlBot API became unavailable, the developer has made a reincarnation of the app for FreeDictionaryAPI