### PR TITLE
Fix Flud+ Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 	- `MDY` [Tremotesf](https://github.com/equeim/tremotesf-android) <sup>`FOSS`</sup>
 	- `MD` [qBittorrent Manager](https://github.com/Yash-Garg/qBittorrent-Manager) <sup>`FOSS`</sup>
 	- `MD` [Nyanpasu](https://github.com/Lucchetto/Nyanpasu) <sup>`FOSS`</sup> <sup>`🪦`</sup>
-	- `MD` [Flud](https://play.google.com/store/apps/details?id=com.delphicoder.flud)
+	- `MD` [Flud+](https://play.google.com/store/apps/details?id=com.delphicoder.flud.paid)<sup>`💰`</sup>
 	- `MD` [CatTorrent](https://play.google.com/store/apps/details?id=com.piratecats.cattorrent)
 - **Miscellaneous**
 	- `MDY` [Tweeload](https://play.google.com/store/apps/details?id=tweeload.twitter.video.downloader)


### PR DESCRIPTION
Apparently when I checked the Flud app for torrenting, the MD theme is only available for the [paid version](https://play.google.com/store/apps/details?id=com.delphicoder.flud.paid), which can also be checked on the images on the Play Store.

It is a special feature for the paid app and not for the [free version](https://play.google.com/store/apps/details?id=com.delphicoder.flud).

Hence, personally for me, adding the <sup>`💰`</sup> tag and changing the link and name to the paid version of the app makes sense.