### PR TITLE
fix JoiPlay website

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 -  **Emulators**
 	- `MDY` [Lemuroid](https://github.com/Swordfish90/Lemuroid) <sup>`FOSS`</sup>
 	- `MDY` [Rekado](https://github.com/MenosGrante/Rekado) <sup>`FOSS`</sup>
-	- `MDY` [Joiplay](https://joiplay.org/)
+	- `MDY` [Joiplay](https://joiplay.net/)
 	- `MDY` [Dolphin Emulator](https://github.com/dolphin-emu/dolphin) <sup>`FOSS`</sup>
 	- `MDY` [Lime3DS](https://github.com/Lime3DS/Lime3DS) <sup>`FOSS`</sup>
 - **Tools**


### PR DESCRIPTION
JoiPlay's website is [joiplay.net](https://joiplay.net), not [joiplay.org](https://joiplay.org)