### PR TITLE
Changing "K-9 Mail" to "Thunderbird" following rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MDY` [Infomaniak kMail](https://github.com/Infomaniak/android-kMail) <sup>`FOSS`</sup>
 - `MDY` [Spark Mail](https://play.google.com/store/apps/details?id=com.readdle.spark)
 - `MDY` [ltt.rs](https://codeberg.org/iNPUTmice/lttrs-android) <sup>`FOSS`</sup>
-- `MD` [K-9 Mail](https://github.com/thunderbird/thunderbird-android)  <sup>`FOSS`</sup>
+- `MD` [Thunderbird](https://github.com/thunderbird/thunderbird-android)  <sup>`FOSS`</sup>
 - `MY` [FairEmail](https://github.com/M66B/FairEmail) <sup>`FOSS`</sup>
 
 <sub>[📜Table Of Contents](#-table-of-contents)</sub>


### PR DESCRIPTION
Replaced references to "K-9 Mail" with its new name, "Thunderbird"