### PR TITLE
Add new MD3E/MDY apps and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MDY` [Immich](https://github.com/immich-app/immich) <sup>`FOSS`</sup>
 - `MD3E` [RvKernel Manager](https://github.com/Rve27/RvKernel-Manager) <sup>`FOSS`</sup>
 - `MD3E` [LibreTorrent](https://gitlab.com/proninyaroslav/libretorrent) <sup>`FOSS`</sup>
+- `MY` [Piko for Twitter](https://github.com/crimera/twitter-apk) <sup>`FOSS`</sup>
+- `MDY` [Pixel Weather](https://www.apkmirror.com/apk/google-inc/pixel-weather/)
 - `MDY` [Athena](https://github.com/Kin69/Athena) <sup>`FOSS`</sup>
 - `MDY` [Driftly](https://github.com/DP-Hridayan/Driftly) <sup>`FOSS`</sup>
 - `MDY` [ShikiApp](https://github.com/pewaru-333/ShikiApp) <sup>`FOSS`</sup>
@@ -271,8 +273,6 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MDY` [LightNovelReader](https://github.com/dmzz-yyhyy/LightNovelReader) <sup>`FOSS`</sup>
 - `MDY` [Ampersand](https://github.com/NyaomiDEV/Ampersand) <sup>`FOSS`</sup>
 - `MDY` [AppListBackup](https://github.com/AndroidLabs-org/AppListBackup) <sup>`FOSS`</sup>
-- `MDY` [Dooz](https://github.com/yamin8000/Dooz) <sup>`FOSS`</sup>
-- `MDY` [DNSNet](https://github.com/t895/DNSNet) <sup>`FOSS`</sup> <sup>`FORK`</sup>
 
 <sub>[📜Table Of Contents](#-table-of-contents)</sub>
 
@@ -312,6 +312,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MDY` [Infinity for Reddit](https://github.com/Docile-Alligator/Infinity-For-Reddit) <sup>`FOSS`</sup>
 
 #### 🕊️ **X (Twitter)**
+- `MY` [Piko for Twitter](https://github.com/crimera/twitter-apk) <sup>`FOSS`</sup>
 - `MDY` [Quacker](https://github.com/TheHCJ/Quacker) <sup>`FOSS`</sup>
 - `MDY` [Focust](https://play.google.com/store/apps/details?id=allen.town.focus.twitter)
 - `MD` [Squawker](https://github.com/j-fbriere/squawker) <sup>`FOSS`</sup> <sup>`🪦`</sup>
@@ -1513,6 +1514,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 
 ---
 ### 🌦️ Weather
+- `MDY` [Pixel Weather](https://www.apkmirror.com/apk/google-inc/pixel-weather/)
 - `MDY` [WeatherMaster](https://github.com/PranshulGG/WeatherMaster) <sup>`FOSS`</sup>
 - `MDY` [WeatherWise](https://github.com/MGAndroidProjects/WeatherWise-Releases)
 - `MDY` [Weather Today](https://play.google.com/store/apps/details?id=com.kokoschka.michael.weather)


### PR DESCRIPTION
- Tagged updated Google apps as MD3E: https://9to5google.com/2025/08/17/google-material-3-expressive-redesign/
- Tagged Cinexplore, Cofi and Harmonic as MD3E
- Added Immich, RvKernel Manager (https://github.com/nyas1/Material-You-app-list/issues/326), LibreTorrent, Pixel Weather (https://github.com/nyas1/Material-You-app-list/issues/336) and Piko for Twitter (https://github.com/nyas1/Material-You-app-list/issues/332)
- Tagged DarQ and Tivi as dead, removed Repainter as it's no longer available in Play Store
- Updated new apps list