### PR TITLE
Change development status of Omnivore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,7 +1244,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 	- `MDY` [Linkdy](https://play.google.com/store/apps/details?id=com.jgeek00.linkdy)
 	- `MDY` [Linkora](https://github.com/sakethpathike/Linkora)  <sup>`FOSS`</sup>
 	- `MD` [Pinkt for Pinboard](https://github.com/fibelatti/pinboard-kotlin)  <sup>`FOSS`</sup>
-	- `MD` [Omnivore](https://github.com/omnivore-app/omnivore)  <sup>`FOSS`</sup>
+	- `MD` [Omnivore](https://github.com/omnivore-app/omnivore)  <sup>`FOSS`</sup> <sup>`🪦`</sup>
 	- `MD` [frigoligo](https://github.com/casimir/frigoligo)  <sup>`FOSS`</sup>
 
 <sub>[📜Table Of Contents](#-table-of-contents)</sub>


### PR DESCRIPTION
Since Omnivore's development has shut down but it is still possible to host it on your own locally IIRC, I've added the gravestone emoji to indicate so.