### PR TITLE
Add Navic to subsonic clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,7 @@ This list is solely a compilation of apps that adopt the Material You design gui
 	- `MDY` [Jetispot](https://github.com/BobbyESP/Jetispot) <sup>`FOSS`</sup> <sup>`FORK`</sup>
 
 #### 🐡 Subsonic Clients
+- `MD3E` [Navic](https://github.com/paigely/Navic) <sup>`FOSS`</sup>
 - `MDY` [SubTune](https://github.com/TaylorKunZhang/SubTune) <sup>`FOSS`</sup>
 - `MDY` [Ultrasonic](https://gitlab.com/ultrasonic/ultrasonic) <sup>`FOSS`</sup>
 - `MDY` [Youamp](https://github.com/siper/Youamp) <sup>`FOSS`</sup>


### PR DESCRIPTION
Adds my app, [Navic](https://github.com/paigely/Navic), to the subsonic clients list