### PR TITLE
exteragram is not foss

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ This list is solely a compilation of apps that adopt the Material You design gui
 - `MY` [MyInsta](https://t.me/instasmashrepo)
 
 #### ✈️ **Telegram**
-- `MDY` [exteraGram](https://github.com/exteraSquad/exteraGram) <sup>`FOSS`</sup>
 - `MDY` [Cherrygram](https://github.com/arsLan4k1390/Cherrygram) <sup>`FOSS`</sup>
 - `MDY` [OctoGram](https://github.com/OctoGramApp/OctoGram) <sup>`FOSS`</sup>
 - `MDY` [Tool Telegram](https://github.com/trindadedev13/Tool-Telegram) <sup>`FOSS`</sup>
+- `MDY` [exteraGram](https://github.com/exteraSquad/exteraGram)
 - `MY` [OwlGram](https://github.com/OwlGramDev/OwlGram) <sup>`FOSS`</sup> <sup>`🪦`</sup>
 - `MY` [Nekogram](https://github.com/Nekogram/Nekogram) <sup>`FOSS`</sup>
 - `MY` [Nagram](https://github.com/NextAlone/Nagram) <sup>`FOSS`</sup>


### PR DESCRIPTION
The app is not actually foss anymore
<img width="1029" height="201" alt="Снимок экрана от 2026-01-22 23-00-17" src="https://github.com/user-attachments/assets/f6195b1c-2b62-4de6-ac1a-a6e7b536abc3" />
<img width="190" height="82" alt="Снимок экрана от 2026-01-22 23-00-37" src="https://github.com/user-attachments/assets/10d91ea3-c2d1-445d-8e7d-4bc1991d5aa3" />
